### PR TITLE
fix: avoid return io.UnexpectedEOF error while remain is zero

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -858,7 +858,7 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 
 	var msgs *messageSetReader
 	if err == nil {
-		if highWaterMark == offset {
+		if highWaterMark == offset || remain == 0 {
 			msgs = &messageSetReader{empty: true}
 		} else {
 			msgs, err = newMessageSetReader(&c.rbuf, remain)


### PR DESCRIPTION
resolves UnexpectedEOF 